### PR TITLE
Ensure flow.cylc.processed is recognised as a Cylc file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,14 @@
 # Change Log
 
+## v1.0.3
+
+Bug fixes:
+- Fix bug where `flow.cylc.processed` was not being recognised as a Cylc file
+
 ## v1.0.2
 
 Enhancements:
-- Support for Cylc8-alpha global config files
+- Support for Cylc 8 global config files
 
 ## v1.0.1
 

--- a/package.json
+++ b/package.json
@@ -24,11 +24,13 @@
                     "Cylc",
                     "cylc"
                 ],
+                "extensions": [
+                    ".cylc",
+                    ".cylc.processed"
+                ],
                 "filenamePatterns": [
                     "*suite*.rc",
                     "suite*.rc.*",
-                    "*.cylc",
-                    "*.cylc.*",
                     "flow.rc",
                     "flow-tests.rc"
                 ],


### PR DESCRIPTION
Closes #15 (`flow.cylc.processed` not opening as a Cylc file)

Can test this (but don't have to if it's too much hassle):
1. Reproduce bug to begin with, by opening a `flow.cylc.processed` file in VSCode (there should not be any syntax highlighting applied)
2. Clone (if not already cloned) the repo with the `--recurse-submodules` option and check out this branch
3. Run/debug the development version in a new window by pressing F5.
4. Opening a `flow.cylc.processed` file in the new window and verifying that syntax highlighting is applied